### PR TITLE
feat: Upload supplier's profile image during creation

### DIFF
--- a/src/supplier/supplier.service.ts
+++ b/src/supplier/supplier.service.ts
@@ -149,12 +149,12 @@ class SupplierService {
         await this.buildContactSupplier(supplier.idSupplier, request, transaction);
       }
 
-      const identifier = crypto.randomUUID();
       if (filePath) {
+        const identifier = crypto.randomUUID();
         await uploadFile(filePath, identifier, "image/jpg", "image-profile");
+        supplier.imageProfileUrl = `https://sacmaback.blob.core.windows.net/image-profile/${identifier}.png`;
       }
 
-      supplier.imageProfileUrl = `https://sacmaback.blob.core.windows.net/image-profile/${identifier}.png`;
       await supplier.save({ transaction });
 
       await transaction.commit();


### PR DESCRIPTION
This commit modifies the `supplier.service.ts` file to upload the supplier's profile image during creation. It generates a random identifier using `crypto.randomUUID()` and uploads the image file to the appropriate location. The `imageProfileUrl` property of the supplier is then updated with the URL of the uploaded image. This enhancement improves the user experience by allowing suppliers to have a profile image associated with their account.